### PR TITLE
Refine use navigation param

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,23 @@ function MyLinkButton() {
 }
 ```
 
-### useNavigationParam(paramName)
+### useNavigationParam(paramName, fallbackValue)
 
 Access a param for the current navigation state
 
 ```js
 function MyScreen() {
-  const name = useNavigationParam('name');
+  const [name, setName] = useNavigationParam('name', 'fallbackName');
+  useEffect(() => {
+    setName('Name')
+  }, []);
+
   return <p>name is {name}</p>;
 }
 ```
 
-Literally the same as `useNavigation().getParam(paramName)`
+Similar to `useState` this function returns a pair of values: the current navigation param and a function that updates it.
+It takes two arguments, the name of the param and an optional fallback value, if the navigation param is undefined.
 
 ### useNavigationState()
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@ See an example web app which uses react-navigation and hooks on the client and t
 
 https://github.com/react-navigation/web-server-example
 
-## Breaking Changes
-
-- `useNavigationParam()` returns an array of the navigation param and a function to update the param instead of of only the navigation param.
-
-As long as this project is in `alpha`, there can be further breaking changes.
-
-
 ## Docs
 
 `yarn add react-navigation-hooks`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ See an example web app which uses react-navigation and hooks on the client and t
 
 https://github.com/react-navigation/web-server-example
 
+## Breaking Changes
+
+- `useNavigationParam()` returns an array of the navigation param and a function to update the param instead of of only the navigation param.
+
+As long as this project is in `alpha`, there can be further breaking changes.
+
+
 ## Docs
 
 `yarn add react-navigation-hooks`

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -19,7 +19,7 @@ export function useNavigationParam<T extends keyof NavigationParams>(
   paramName: T,
   fallbackValue?
 ) {
-  const {getParam, setParams} = useNavigation()
+  const { getParam, setParams } = useNavigation()
   return [
     getParam(paramName, fallbackValue),
     (newValue: NonNullable<NavigationParams[T]>) => setParams({ [paramName]: newValue }),

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from 'react';
+import { useState, useContext, useEffect, useCallback } from 'react';
 import { NavigationContext } from '@react-navigation/core';
 // TODO: move to "react-navigation" when https://github.com/react-navigation/react-navigation/pull/5276
 // get merged
@@ -19,11 +19,18 @@ export function useNavigationParam<T extends keyof NavigationParams>(
   paramName: T,
   fallbackValue?: NavigationParams[T]
 ) {
-  const { getParam, setParams } = useNavigation()
+  const { getParam, setParams } = useNavigation();
+  const setParamValue = useCallback(
+    () => {
+      return (newValue: NavigationParams[T]) =>
+        setParams({ [paramName]: newValue });
+    },
+    [setParams]
+  );
   return [
     fallbackValue ? getParam(paramName, fallbackValue) : getParam(paramName),
-    (newValue: NavigationParams[T]) => setParams({ [paramName]: newValue }),
-  ]
+    setParamValue(),
+  ];
 }
 
 export function useNavigationState() {

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -16,9 +16,14 @@ export function useNavigation<S>(): NavigationScreenProp<S & NavigationRoute> {
 }
 
 export function useNavigationParam<T extends keyof NavigationParams>(
-  paramName: T
+  paramName: T,
+  fallbackValue?
 ) {
-  return useNavigation().getParam(paramName);
+  const {getParam, setParams} = useNavigation()
+  return [
+    getParam(paramName, fallbackValue),
+    (newValue: NonNullable<NavigationParams[T]>) => setParams({ [paramName]: newValue }),
+  ]
 }
 
 export function useNavigationState() {

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -17,12 +17,12 @@ export function useNavigation<S>(): NavigationScreenProp<S & NavigationRoute> {
 
 export function useNavigationParam<T extends keyof NavigationParams>(
   paramName: T,
-  fallbackValue?
+  fallbackValue?: NavigationParams[T]
 ) {
   const { getParam, setParams } = useNavigation()
   return [
-    getParam(paramName, fallbackValue),
-    (newValue: NonNullable<NavigationParams[T]>) => setParams({ [paramName]: newValue }),
+    fallbackValue ? getParam(paramName, fallbackValue) : getParam(paramName),
+    (newValue: NavigationParams[T]) => setParams({ [paramName]: newValue }),
   ]
 }
 

--- a/src/__tests__/Hooks-test.tsx
+++ b/src/__tests__/Hooks-test.tsx
@@ -1,4 +1,4 @@
-import { default as React, useState } from 'react';
+import { default as React, useState, useEffect } from 'react';
 import * as renderer from 'react-test-renderer';
 import {
   createSwitchNavigator,
@@ -24,13 +24,21 @@ const HomeScreen = () => {
 };
 
 const DetailsScreen = () => {
-  const from = useNavigationParam('from');
+  const [from] = useNavigationParam('from');
   return <p>{from}</p>;
 };
 
 const OtherScreen = () => {
   const { routeName } = useNavigationState();
   return <p>{routeName}</p>;
+};
+
+const ParamScreen = () => {
+  const [param, setParam] = useNavigationParam('param', 'fallback');
+  useEffect(() => {
+    setParam('Value')
+  }, []);
+  return <p>{param}</p>;
 };
 
 const KeyScreen = () => {
@@ -66,6 +74,7 @@ const AppNavigator1 = createSwitchNavigator(
     Home: HomeScreen, // { nav: { "index": 0 ...
     Details: DetailsScreen, // { nav: { "index": 1 ...
     Other: OtherScreen, // { nav: { "index": 2 ...
+    Param: ParamScreen, // { nav: { "index": 3 ...
   },
   {
     initialRouteName: 'Home',
@@ -99,6 +108,13 @@ describe('AppNavigator1 Stack', () => {
   it('useNavigationParam: Get passed parameter', () => {
     const children = navigationContainer.toJSON().children;
     expect(children).toContain('Home');
+  });
+
+  it('useNavigationParam: Set parameter', () => {
+    const instance = navigationContainer.getInstance();
+    instance.dispatch(NavigationActions.navigate({ routeName: 'Param' }));
+    const children = navigationContainer.toJSON().children;
+    expect(children).toContain('Value');
   });
 
   afterEach(() => {


### PR DESCRIPTION
Introduces a `useState` like API for `useNavigationParam` as suggested in #19  and allows a fallback value as a second argument.

Theres also an updated and one added test as well as updated documentation and a new warning because of this breaking changes.

Currently the linter is failing because of a missing type for `fallbackValue`.
Since I'm not very fluent in typescript I'd couldn't find a solution that doesn't end in errors :/ 