### PR TITLE
Generate declaration file when building for release

### DIFF
--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
+    "declaration": true,
     "sourceMap": false
   },
   "exclude": ["**/__tests__", "dist", ".jest", "node_modules"]


### PR DESCRIPTION
Add the `declaration: true` option within the configuration file when this package is built for release.

@ericvicenti This should allow [this issue](https://github.com/react-navigation/hooks/issues/7) to be closed.

Thanks!