### PR TITLE
fix: catch undefined navigation

### DIFF
--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -33,9 +33,9 @@ export function useNavigationEvents(handleEvt: NavigationEventCallback) {
   useEffect(
     () => {
       if (!navigation) {
-        return
+        return;
       }
-      
+
       const subsA = navigation.addListener(
         'action' as any // TODO should we remove it? it's not in the published typedefs
         , handleEvt);

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -32,6 +32,10 @@ export function useNavigationEvents(handleEvt: NavigationEventCallback) {
   const navigation = useNavigation();
   useEffect(
     () => {
+      if (!navigation) {
+        return
+      }
+      
       const subsA = navigation.addListener(
         'action' as any // TODO should we remove it? it's not in the published typedefs
         , handleEvt);


### PR DESCRIPTION
In my case I have an `onFocus` prop in a reusable component which can be used across the app. The `onFocus` prop will be called in the `useNavigationEvents` hook whenever the component is focused. However, in some cases the `navigation` is undefined because the reusable component is used in places where no navigation is present. Since we cannot conditionally use hooks, this will always fail.

In addition to the simple return in the hook we could also print a comment to inform the user about this behaviour.