### PR TITLE
fix: Use @react-navigation/core 

### DIFF
--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -9,6 +9,9 @@ import {
 
 import {
   NavigationContext,
+} from '@react-navigation/core';
+
+import {
   NavigationScreenProp,
   NavigationRoute,
   NavigationParams,

--- a/typings/core.d.ts
+++ b/typings/core.d.ts
@@ -1,0 +1,5 @@
+declare module "@react-navigation/core" {
+  import { Context } from 'react';
+
+  export const NavigationContext: Context<any>;
+}

--- a/typings/core.d.ts
+++ b/typings/core.d.ts
@@ -1,5 +1,5 @@
-declare module "@react-navigation/core" {
-  import { Context } from 'react';
+declare module '@react-navigation/core' {
+  import { NavigationContext } from 'react-navigation';
 
-  export const NavigationContext: Context<any>;
+  export const NavigationContext;
 }


### PR DESCRIPTION
This PR fix issue with a web version.

Related https://github.com/react-navigation/hooks/issues/59