### PR TITLE
Fix generic type of useNavigationParam

### DIFF
--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -17,7 +17,7 @@ import {
   EventType,
 } from 'react-navigation';
 
-export function useNavigation<S>(): NavigationScreenProp<S & NavigationRoute> {
+export function useNavigation<S, P = NavigationParams>(): NavigationScreenProp<S & NavigationRoute, P> {
   const navigation = useContext(NavigationContext) as any; // TODO typing?
   if (!navigation) {
     throw new Error(
@@ -29,10 +29,10 @@ export function useNavigation<S>(): NavigationScreenProp<S & NavigationRoute> {
   return navigation;
 }
 
-export function useNavigationParam<T extends keyof NavigationParams>(
-  paramName: T
+export function useNavigationParam<Params extends NavigationParams = NavigationParams>(
+  paramName: keyof Params
 ) {
-  return useNavigation().getParam(paramName);
+  return useNavigation<unknown, Params>().getParam(paramName) as Params[typeof paramName] | undefined
 }
 
 export function useNavigationState() {


### PR DESCRIPTION
This fixes an issue where the return type `useNavigationParam` wasn't meaningful (it just returns `any`).

## Without generic (backwards compatibility):

<img width="314" alt="Screen Shot 2021-03-03 at 3 08 07 PM" src="https://user-images.githubusercontent.com/868317/109873547-81ee8180-7c33-11eb-9e6a-af180bf3f0dc.png">

## With generic (helpful type):

<img width="465" alt="Screen Shot 2021-03-03 at 3 07 42 PM" src="https://user-images.githubusercontent.com/868317/109873612-99c60580-7c33-11eb-8ab3-d3aedbb346b5.png">

As a side-effect, I think this also fixes #42 since you can now pass the `P` type in the `useNavigation` hook (it defaults to the unspecific `NavigationParams` type)